### PR TITLE
docs: update readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## Introduction
 
-This is the public roadmap for the https://pactflow.io product platform.
+This is the public roadmap for the [`pactflow.io`](https://pactflow.io) product platform.
 
 Knowing about our upcoming products and priorities helps our customers plan. This repository contains information about what we are working on and allows all customers to give direct feedback.
 
 - [See our vision and product roadmap approach »](https://github.com/pactflow/roadmap/discussions/67)
+- [View tickets in this repo »](https://github.com/pactflow/roadmap/issues)
+- [View tickets in the Pact Foundation roadmap »](https://github.com/pact-foundation/roadmap/issues)
 - [See the PactFlow roadmap »](https://github.com/orgs/pactflow/projects/3)
-- [View the OSS Roadmap »](https://pact.canny.io/) (external)
 
 ## Developer Preview Programs
 


### PR DESCRIPTION
Some of the links were no longer used (Canny) or missing (GitHub Issues).